### PR TITLE
Fix deploy button link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Click the button below to deploy, and remember to order a Star if it works:
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aditya-shri/VPN/tree/main)
 ---
 
 Native V2Ray deployment: <https://github.com/ygcaicn/v2ray-heroku>


### PR DESCRIPTION
Hello!

Thanks for great project! I spread word about it [on Hackers News](https://news.ycombinator.com/item?id=27041460) and other people seem to like it too.

This PR adds `template` parameter to Heroku deploy button on main page. This way deploy button will work on Heroku Elements page (at this moment it doesn't) and will not depend on referrer where link where navigated from.