### PR TITLE
Update default cipher since stream cipher support was discontinued

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,8 +4,8 @@
   "keywords": ["V2ray", "Shadowsocks", "V2Ray-plugin"],
   "env": {
      "ENCRYPT": {
-      "description": "Encryption method, due to https blessing, choose the simplest one, default: rc4-md5, others are（aes-256-cfb,chacha20-ietf-poly1305,salsa20,chacha20-ietf etc.）",
-      "value": "rc4-md5"
+      "description": "Encryption method, due to https blessing, choose the simplest one, default: chacha20-ietf-poly1305, others are（aes-256-cfb,chacha20-ietf-poly1305,salsa20,chacha20-ietf etc.）",
+      "value": "chacha20-ietf-poly1305"
     },
      "PASSWORD": {
       "description": "The password of shadowsocks, you can use uuid as the password (http://www.uuid.online/ online generation)",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 echo ${PASSWORD}
 
 if [[ -z "${ENCRYPT}" ]]; then
-  ENCRYPT="rc4-md5"
+  ENCRYPT="chacha20-ietf-poly1305"
 fi
 
 


### PR DESCRIPTION
This PR updates default cipher because [latest release](https://github.com/shadowsocks/shadowsocks-windows/releases/tag/4.4.0.0) of shadowsocks clients discontinues support for stream ciphers. This way everything will still work by default with latest clients.

`chacha20-ietf-poly1305` cipher was suggested as default because of following reasons:

- This cipher has great performance both on mobile devices without AES-NI and desktops. Won't hurt much.
- It's a good secure AEAD cipher proposed by independent researchers and accepted as a modern standard.